### PR TITLE
Create haxelib.json to be added to haxelib

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -1,0 +1,15 @@
+{
+  "name": "aseprite",
+  "url" : "https://github.com/PongoEngine/haxe-aseprite",
+  "license": "MIT",
+  "tags": ["pixel-art",
+    "pixelart",
+    "parser",
+    "haxe",
+    "gamedev"],
+  "description": "Parser for .ase and .aseprite files.",
+  "version": "1.0.0",
+  "classPath": "Sources",
+  "releasenote": "haxe-aseprite was created for the GitHub GameOff. I've tested it for my needs however I would love for this to be feature complete. If you have access to aseprite files that break the parser send them my way!",
+  "contributors": ["PongoEngine"]
+}


### PR DESCRIPTION
So that this lib can be installed with `haxelib install` (or, if you don't want to register & actually push to haxelib, `haxelib git` I believe?)